### PR TITLE
Remove unapply filter

### DIFF
--- a/liblarch/filters_bank.py
+++ b/liblarch/filters_bank.py
@@ -121,7 +121,6 @@ class FiltersBank:
         """
         if not self.available_filters.has_key(filter_name):
             if self.custom_filters.has_key(filter_name):
-                self.unapply_filter(filter_name)
                 self.custom_filters.pop(filter_name)
                 return True
             else:


### PR DESCRIPTION
Hi, this commit remove a single line in the filterbank class, in the "remove_filter" method. Indeed, this line calls the FilterBanks.unapply_filter method, which doesn't exist. It's probably an artefact from an earlier implementation.
