### PR TITLE
Fix PyGIWarning about Gtk version

### DIFF
--- a/liblarch_gtk/__init__.py
+++ b/liblarch_gtk/__init__.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 from gi.repository import GObject
 


### PR DESCRIPTION
When using Python 3.5, importing liblarch_gtk cause this error/warning:

_PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded. from gi.repository import Gtk, Gdk_
