### PR TITLE
Disallow python2 installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     license='LGPLv3',
     name='liblarch',
     packages=['liblarch', 'liblarch_gtk'],
+    python_requires=">=3.5",
     description=(
         'LibLarch is a python library built to easily handle '
         'data structures such as lists, trees and directed acyclic graphs '


### PR DESCRIPTION
print method doesn't exist in python2, and fails to run test suite.

```
  File "/build/source/liblarch/__init__.py", line 21, in <module>
    from .tree import MainTree
  File "/build/source/liblarch/tree.py", line 416
    print(output, end=' ')
                     ^
SyntaxError: invalid syntax
```
related PR: https://github.com/NixOS/nixpkgs/pull/94686#discussion_r465376074