### PR TITLE
Added PyPI Metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,18 @@
 # -----------------------------------------------------------------------------
 
 from distutils.core import setup
+import codecs
+import os
+
+def read(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    HERE = os.path.abspath(os.path.dirname(__file__))
+
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
 
 setup(
     version='3.1.0',
@@ -26,9 +38,25 @@ setup(
     author='Lionel Dricot & Izidor Matušov',
     author_email='gtg-contributors@lists.launchpad.net',
     license='LGPLv3',
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     name='liblarch',
     packages=['liblarch', 'liblarch_gtk'],
     python_requires=">=3.5",
+    keywords = ["gtk", "treeview", "treemodel"],
+    classifiers = [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: X11 Applications :: GTK",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.5",
+        "Topic :: Desktop Environment :: Gnome",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Software Development :: User Interfaces",
+    ],
     description=(
         'LibLarch is a python library built to easily handle '
         'data structures such as lists, trees and directed acyclic graphs '


### PR DESCRIPTION
Fixes  #24 (partially).

This pull request doesn't actually upload anything to PyPI. It just adds metadata that makes the repository page appear nicely. A test upload using this metadata (with a name with a throwaway suffix because names can't be reused) can be found [here](https://test.pypi.org/project/liblarch202107311843/3.1.0/).

For this particular pull request, I would just recommend you check the above-linked PyPI page to see if the metadata is correct, as well as installing the package using `pip install -i https://test.pypi.org/simple/ liblarch202107311843==3.1.0` and seeing if it works correctly in your existing development environment.

If the results are satisfactory, I can give you abbreviated instructions on how to use the PyPI test server, and once you are all set, you will be ready to deploy `liblarch` on the main PyPI repository. I can't do the final upload for you, or at least I would prefer not to, since I'd prefer you control the `liblarch` namespace on PyPI.