### PR TITLE
Expliciting LGPLv3-or-later in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ separation between your data themselves (Model) and how they are displayed (View
 
 ## Credits
 
-Liblarch is published under the LGPLv3 license.
+Liblarch is published under the LGPLv3 license, or (at your option) any later version.
 
 Authors:
  - [Lionel Dricot](https://github.com/ploum)


### PR DESCRIPTION
I researched and found that to license the source code under LGPLv3-or-later
you just need to specify it in the source code header, but the license is the
same so I don't need to make any changes to the LICENSE file and the source
files already have the explicit "or any later version" in the header.

I'm just modifying the README file because Github doesn't have a way to tell
the person visiting the repository that the program is LGPLv3-or-later, it
just says LGPLv3, so I think the most effective way to specify it is to put
it in the README file.
