### PR TITLE
Fixed some pytest warnings

### DIFF
--- a/tests/signals_testing.py
+++ b/tests/signals_testing.py
@@ -22,7 +22,7 @@ import time
 
 from tests.watchdog import Watchdog
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 
 class SignalCatcher(object):
@@ -135,8 +135,7 @@ class GobjectSignalsManager(object):
         This function returns only when the gobject main loop is running
         '''
         def gobject_main_loop():
-            GObject.threads_init()
-            self.main_loop = GObject.MainLoop()
+            self.main_loop = GLib.MainLoop()
             self.main_loop.run()
         threading.Thread(target=gobject_main_loop).start()
         while (not hasattr(self, 'main_loop') or

--- a/tests/test_signal_testing.py
+++ b/tests/test_signal_testing.py
@@ -20,12 +20,12 @@
 import unittest
 from gi.repository import GObject
 import uuid
+from gi.repository import GLib
 
 from tests.signals_testing import SignalCatcher, GobjectSignalsManager
 
 
 class TestSignalTesting(unittest.TestCase):
-
     def setUp(self):
         self.gobject_signal_manager = GobjectSignalsManager()
         self.gobject_signal_manager.init_signals()
@@ -36,7 +36,8 @@ class TestSignalTesting(unittest.TestCase):
     def test_signal_catching(self):
         generator = FakeGobject()
         arg = str(uuid.uuid4())
-        with SignalCatcher(self, generator, 'one') as [signal_catched_event, signal_arguments]:
+        with SignalCatcher(self, generator,
+                           'one') as [signal_catched_event, signal_arguments]:
             generator.emit_signal('one', arg)
             signal_catched_event.wait()
         self.assertEqual(len(signal_arguments), 1)
@@ -52,4 +53,4 @@ class FakeGobject(GObject.GObject):
     }
 
     def emit_signal(self, signal_name, argument):
-        GObject.idle_add(self.emit, signal_name, argument)
+        GLib.idle_add(self.emit, signal_name, argument)


### PR DESCRIPTION
When runing pytest I got some warnings about deprecated function calls.
Here are most of the changes:

* replaced `GObject.MainLoop` for `GLib.MainLoop`
* Since version 3.11, calling threads_init is no longer needed, so I
removed this call. See: https://wiki.gnome.org/PyGObject/Threading
* replaced `GObject.idle_add` for `GLib.idle_add`
* replaced `assert_` for `assertTrue`

LSP warned me about some lines that were greater than 79 characters,
I think this may not be very important, but I have fixed this anyway.

Also, there was a warning about not using bare `execept` at the line 51
of the `watchdog.py` file. But I'm not really a python developer so
I wouldn't know how to fix it.

I ran the pytest again and I don't seem to have breaked anything.
