### PR TITLE
Fix collapsing/expanding future node retry

### DIFF
--- a/liblarch_gtk/__init__.py
+++ b/liblarch_gtk/__init__.py
@@ -268,7 +268,15 @@ class TreeView(Gtk.TreeView):
 
         if schedule_next:
             self.basetree.queue_action(
-                node_id, collapsing_method, param=llpath)
+                node_id, self._collapse_node_retry,
+                param=(llpath, collapsing_method))
+
+    def _collapse_node_retry(self, param):
+        """
+        Node to be collapsed/expand found, so re-try now with correct
+        and preserved parameters.
+        """
+        self.collapse_node(param[0], collapsing_method=param[1])
 
     def show(self):
         """ Shows the TreeView and connect basetreemodel to LibLarch """

--- a/tests/test_liblarch.py
+++ b/tests/test_liblarch.py
@@ -209,7 +209,7 @@ class TestLibLarch(unittest.TestCase):
         col['renderer'] = ['markup', render_text]
         col['value'] = [str, lambda node: node.get_id()]
         desc['titles'] = col
-        TreeView(self.view, desc)
+        self.treeview = TreeView(self.view, desc)
         # initalize gobject signaling system
         self.gobject_signal_manager = GobjectSignalsManager()
         self.gobject_signal_manager.init_signals()
@@ -2001,3 +2001,23 @@ class TestLibLarch(unittest.TestCase):
             if not self.view.node_has_child(node_id):
                 node_count -= 1
                 self.tree.del_node(node_id)
+
+    def test_crash_when_collapsing_future_nodes(self):
+        """
+        Due to a mistake trying to collapse a node that isn't in the tree yet
+        causes it to schedule that operation for later, except with the wrong
+        argument type, making PyGObject complain.
+        """
+        self.treeview.collapse_node(('123123123123',))  # Should schedule
+        self.tree.add_node(DummyNode('123123123123')) # Would've errored
+        # TypeError: argument path: Expected Gtk.TreePath, but got tuple
+
+    def test_crash_when_expanding_future_nodes(self):
+        """
+        Due to a mistake trying to expand a node that isn't in the tree yet
+        causes it to schedule that operation for later, except with the wrong
+        argument type, making PyGObject complain.
+        """
+        self.treeview.expand_node(('123123123123',)) # Should schedule
+        self.tree.add_node(DummyNode('123123123123')) # Would've errored
+        # TypeError: argument path: Expected Gtk.TreePath, but got tuple


### PR DESCRIPTION
Previously, when trying to collapse (or expand) an non-existing node,
liblarch would remember to do the operation when it sees the node being
added.
However, they pass the liblarch path object instead of the Gtk.TreePath
object, so PyGObject will complain about invalid type:

    TypeError: argument path: Expected Gtk.TreePath, but got tuple

For https://github.com/getting-things-gnome/gtg/issues/726