### PR TITLE
Fix typos

### DIFF
--- a/examples/contact_list/contact_list.py
+++ b/examples/contact_list/contact_list.py
@@ -131,7 +131,7 @@ class NodeTeam(TreeNode):
     """ Each team is also a node """
     def __init__(self, node_id):
         TreeNode.__init__(self, node_id)
-        # A team cannot have parents. This is arbitrarly done for the purpose
+        # A team cannot have parents. This is arbitrarily done for the purpose
         # of this example.
         self.set_parents_enabled(False)
 
@@ -329,7 +329,7 @@ class ContactListWindow(object):
 class CellRendererTags(Gtk.CellRenderer):
     """ Custom CellRenderer that will make a coloured circle
 
-    This is aboslutely not needed for liblarch. The purpose of using it is
+    This is absolutely not needed for liblarch. The purpose of using it is
     to show that liblarch works with complex cellrenderer too.
     """
     __gproperties__ = {

--- a/liblarch/__init__.py
+++ b/liblarch/__init__.py
@@ -158,7 +158,7 @@ class Tree(object):
 
         @filter_name : name to give to the filter
         @filter_func : the function that will filter the nodes
-        @parameters : some default parameters fot that filter
+        @parameters : some default parameters for that filter
         Return True if the filter was added
         Return False if the filter_name was already in the bank
         """

--- a/liblarch/filteredtree.py
+++ b/liblarch/filteredtree.py
@@ -25,14 +25,14 @@ class FilteredTree(object):
     LibLarch.
 
     FilteredTree transforms general changes in tree like creating/removing
-    relationships between nodes and adding/updating/removing nodes into a serie
+    relationships between nodes and adding/updating/removing nodes into a series
     of simple steps which can be for instance by GTK Widget.
 
     FilteredTree allows filtering - hiding certain nodes defined by
     a predicate.
 
     The reason of most bugs is that FilteredTree is request to update a node.
-    FilteredTree must update its ancestors and also decestors. You cann't do
+    FilteredTree must update its ancestors and also decestors. You can't do
     that by a simple recursion.
     """
 
@@ -376,7 +376,7 @@ class FilteredTree(object):
 
     def __node_parents(self, node_id):
         """ Returns parents of the given node. If node has no parent or
-        no displyed parent, return the virtual root.
+        no displayed parent, return the virtual root.
         """
         if node_id == self.root_id:
             raise ValueError("Requested a parent of the root node")

--- a/liblarch/viewtree.py
+++ b/liblarch/viewtree.py
@@ -36,9 +36,9 @@ class ViewTree(object):
            changes.  If FilteredTree is used, it is connected to MainTree
            to handle changes and then send id to ViewTree if it applies.
 
-           @param maintree: a Tree object, cointaining all the nodes
+           @param maintree: a Tree object, containing all the nodes
            @param filters_bank: a FiltersBank object. Filters can be added
-                                dinamically to that.
+                                dynamically to that.
            @param refresh: if True, this ViewTree is automatically refreshed
                            after applying a filter.
            @param static: if True, this is the view of the complete maintree.
@@ -250,7 +250,7 @@ class ViewTree(object):
         """ Returns displayed parents of the given node, or [] if there is no
         parent (such as if the node is a child of the virtual root),
         or if the parent is not displayable.
-        Doesn't check wheter node node_id is displayed or not.
+        Doesn't check whether node node_id is displayed or not.
         (we only care about parents)
         """
         if self.static:

--- a/liblarch_gtk/__init__.py
+++ b/liblarch_gtk/__init__.py
@@ -117,7 +117,7 @@ class TreeView(Gtk.TreeView):
 
         types = []
         sorting_func = []
-        # Build the first coulumn if user starts with new_colum=False
+        # Build the first column if user starts with new_colum=False
         col = Gtk.TreeViewColumn()
 
         # Build columns according to the order
@@ -168,7 +168,7 @@ class TreeView(Gtk.TreeView):
                     col.set_sort_column_id(sort_num)
 
                 if 'sorting_func' in desc:
-                    # Use special funcion for comparing, e.g. dates
+                    # Use special function for comparing, e.g. dates
                     sorting_func.append((col_num, col, desc['sorting_func']))
 
         self.basetree = tree
@@ -240,7 +240,7 @@ class TreeView(Gtk.TreeView):
     def collapse_node(self, llpath, collapsing_method=None):
         """ Hide children of a node
 
-        This method is needed for "rember collapsed nodes" feature of GTG.
+        This method is needed for "remember collapsed nodes" feature of GTG.
         Transform node_id into paths and those paths collapse. By default all
         children are expanded (see self.expand_all())
 
@@ -313,7 +313,7 @@ class TreeView(Gtk.TreeView):
             return self.sort_col, self.sort_order
 
     def set_col_visible(self, col_name, visible):
-        """ Set visiblity of column.
+        """ Set visibility of column.
         Allow to hide/show certain column """
         col_num, col = self.columns[col_name]
         col.set_visible(visible)
@@ -345,7 +345,7 @@ class TreeView(Gtk.TreeView):
             self.treemodel.set_column_function(self.bg_color_column, func)
         else:
             raise ValueError(
-                "There is no colum %s to use to set color" % color_column)
+                "There is no column %s to use to set color" % color_column)
 
     def _sort_func(self, model, iter1, iter2, func=None):
         """ Sort two iterators by function which gets node objects.
@@ -418,7 +418,7 @@ class TreeView(Gtk.TreeView):
         Enable DND by calling enable_model_drag_dest(),
         enable_model-drag_source()
 
-        It didnt use support from Gtk.Widget(drag_source_set(),
+        It didn't use support from Gtk.Widget(drag_source_set(),
         drag_dest_set()). To know difference, look in PyGTK FAQ:
         http://faq.pyGtk.org/index.py?file=faq13.033.htp&req=show
         """
@@ -460,7 +460,7 @@ class TreeView(Gtk.TreeView):
         """ Handle a drop situation.
 
         First of all, we need to get id of node which should accept
-        all draged nodes as their new children. If there is no node,
+        all dragged nodes as their new children. If there is no node,
         drop to root node.
 
         Deserialize iterators of dragged nodes (see self.on_drag_data_get())
@@ -508,7 +508,7 @@ class TreeView(Gtk.TreeView):
 
         # Get dragged iter as a TaskTreeModel iter
         # If there is no selected task (empty selection.data),
-        # explictly skip handling it (set to empty list)
+        # explicitly skip handling it (set to empty list)
         data = selection.get_data()
         if data == '':
             iters = []

--- a/liblarch_gtk/treemodel.py
+++ b/liblarch_gtk/treemodel.py
@@ -24,7 +24,7 @@ class TreeModel(Gtk.TreeStore):
     """ Local copy of showed tree """
 
     def __init__(self, tree, types):
-        """ Initializes parent and create list of columns. The first colum
+        """ Initializes parent and create list of columns. The first column
         is node_id of node """
 
         self.count = 0
@@ -190,7 +190,7 @@ class TreeModel(Gtk.TreeStore):
         and then deleted.
 
         @param node_id: identification of root node
-        @param path: identification of poistion of root node
+        @param path: identification of position of root node
         @param neworder: new order of children of root node
         """
 

--- a/tests/test_liblarch.py
+++ b/tests/test_liblarch.py
@@ -210,7 +210,7 @@ class TestLibLarch(unittest.TestCase):
         col['value'] = [str, lambda node: node.get_id()]
         desc['titles'] = col
         self.treeview = TreeView(self.view, desc)
-        # initalize gobject signaling system
+        # initialize gobject signaling system
         self.gobject_signal_manager = GobjectSignalsManager()
         self.gobject_signal_manager.init_signals()
         self.recorded_signals = {
@@ -247,7 +247,7 @@ class TestLibLarch(unittest.TestCase):
         return not node.has_child()
 
     # Testing nodes movements in the tree
-    # We test by counting nodes that meet some criterias
+    # We test by counting nodes that meet some criteria
 
     def test_get_node(self):
         """Test that one node can be retrieved from the tree
@@ -759,7 +759,7 @@ class TestLibLarch(unittest.TestCase):
         self.assertRaises(Exception, self.tree.add_parent, '0', 'temp')
         # More complex circular relationship
         self.assertRaises(Exception, self.tree.add_parent, '1', 'temp')
-        # And then printing => if it stops, nothing ciruclar stays there
+        # And then printing => if it stops, nothing circular stays there
         view.print_tree(True)
 
     def test_mainview(self):
@@ -1243,7 +1243,7 @@ class TestLibLarch(unittest.TestCase):
         view = self.tree.get_viewtree(refresh=False)
         test = TreeTester(view)
         view.apply_filter('flatgreen')
-        # all green nodes should be visibles
+        # all green nodes should be visible
         self.assertEqual(self.green_nodes, view.get_n_nodes())
         i = 10
         nodes = []
@@ -1861,7 +1861,7 @@ class TestLibLarch(unittest.TestCase):
 
         For every update in main tree, recount every tag filter """
         # FIXME
-        # Super exterme task count
+        # Super extreme task count
         # Optimal time is 0.917s
         TASK_COUNT = 2000
 

--- a/tests/tree_testing.py
+++ b/tests/tree_testing.py
@@ -18,7 +18,7 @@
 # -----------------------------------------------------------------------------
 
 # If True, the TreeTester will automatically reorder node on the same level
-# as a deleted node. If False, it means that Liblarch has the responsability
+# as a deleted node. If False, it means that Liblarch has the responsibility
 # to handle that itself.
 REORDER_ON_DELETE = False
 

--- a/tests/watchdog.py
+++ b/tests/watchdog.py
@@ -30,7 +30,7 @@ class Watchdog(object):
 
     def __init__(self, timeout, error_function):
         '''
-        Just sets the timeout and the function to execute when an error occours
+        Just sets the timeout and the function to execute when an error occurs
 
         @param timeout: timeout in seconds
         @param error_function: what to execute in case the watchdog timer


### PR DESCRIPTION
Found via `codespell -L shouldbe,childrens`.