### PR TITLE
Replace nose by pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nose
+pytest
 spec
 pyflakes
 pycodestyle

--- a/run-tests
+++ b/run-tests
@@ -19,11 +19,11 @@
 # -----------------------------------------------------------------------------
 
 import sys
-import nose
+import pytest
 
 if __name__ == "__main__":
     # By default, run tests in tests folder
     if len(sys.argv) == 1:
         sys.argv.append('tests')
 
-    nose.main()
+    pytest.main()


### PR DESCRIPTION
Closes: https://github.com/getting-things-gnome/liblarch/issues/35

Just replacing `nose` by `pytest` seems to work in order to drop unmaintained `nose` library.

Do not hesitate to modify if I missed something.

Thanks!